### PR TITLE
Add namespaces and theme dir path

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,8 +1,11 @@
 <?php
 namespace MyProject\Theme;
 
+define( 'MYPROJECT_THEME_DIR', trailingslashit( get_stylesheet_directory() ) );
+
+
 // Theme foundation
-include_once 'includes/config.php';
-include_once 'includes/meta.php';
+include_once MYPROJECT_THEME_DIR . 'includes/config.php';
+include_once MYPROJECT_THEME_DIR . 'includes/meta.php';
 
 // Add other includes to this file as needed.

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
 <?php
+namespace MyProject\Theme;
 
 // Theme foundation
 include_once 'includes/config.php';

--- a/includes/config.php
+++ b/includes/config.php
@@ -2,11 +2,11 @@
 /**
  * Handle all theme configuration here
  **/
+namespace MyProject\Theme\Includes\Config;
+
 
 define( 'MYPROJECT_THEME_URL', get_stylesheet_directory_uri() );
 define( 'MYPROJECT_THEME_STATIC_URL', MYPROJECT_THEME_URL . '/static' );
 define( 'MYPROJECT_THEME_CSS_URL', MYPROJECT_THEME_STATIC_URL . '/css' );
 define( 'MYPROJECT_THEME_JS_URL', MYPROJECT_THEME_STATIC_URL . '/js' );
 define( 'MYPROJECT_THEME_IMG_URL', MYPROJECT_THEME_STATIC_URL . '/img' );
-
-

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -9,7 +9,7 @@ namespace MyProject\Theme\Includes\Meta;
 /**
  * Enqueue front-end css and js.
  **/
-function nqueue_frontend_assets() {
+function enqueue_frontend_assets() {
 	$theme = wp_get_theme();
 	$theme_version = $theme->get( 'Version' );
 

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -3,11 +3,13 @@
  * Includes functions that handle registration/enqueuing of meta tags, styles,
  * and scripts in the document head and footer.
  **/
+namespace MyProject\Theme\Includes\Meta;
+
 
 /**
  * Enqueue front-end css and js.
  **/
-function myproject_enqueue_frontend_assets() {
+function nqueue_frontend_assets() {
 	$theme = wp_get_theme();
 	$theme_version = $theme->get( 'Version' );
 
@@ -16,4 +18,4 @@ function myproject_enqueue_frontend_assets() {
 	wp_enqueue_script( 'script-child', MYPROJECT_THEME_JS_URL . '/script.min.js', array( 'jquery', 'script' ), $theme_version, true );
 }
 
-add_action( 'wp_enqueue_scripts', 'myproject_enqueue_frontend_assets', 11 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_frontend_assets', 11 );


### PR DESCRIPTION
**Description**
See title.

**Motivation and Context**
Solves the open issues and get's this template UTD with how we create child themes based off of UCF-WordPress-Theme, so we can use it more easily in the future

**How Has This Been Tested?**
Double checked them and tested creating a child theme using it.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation. 
  _Requires an update to the third instruction in the [wiki](https://github.com/UCF/CM-WP-Child-Theme-Template/wiki#instructions), so that `MyProject` is also replaced when setting up a child theme from this template. I will add that after this is merged._
- [ ] I have updated the documentation accordingly.
